### PR TITLE
Changing the bundle class name to match the Symfony convention

### DIFF
--- a/DependencyInjection/TheCodingMachineTdbmGraphqlCompilerPass.php
+++ b/DependencyInjection/TheCodingMachineTdbmGraphqlCompilerPass.php
@@ -41,7 +41,7 @@ use TheCodingMachine\Tdbm\GraphQL\GraphQLTypeAnnotator;
 /**
  * Detects controllers and types automatically and tag them.
  */
-class TdbmGraphqlCompilerPass implements CompilerPassInterface
+class TheCodingMachineTdbmGraphqlCompilerPass implements CompilerPassInterface
 {
     /**
      * This Compiler pass adds the GraphQLTypeAnnotator to TDBM configuration

--- a/DependencyInjection/TheCodingMachineTdbmGraphqlExtension.php
+++ b/DependencyInjection/TheCodingMachineTdbmGraphqlExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-class TdbmGraphqlExtension extends Extension
+class TheCodingMachineTdbmGraphqlExtension extends Extension
 {
 
     /**

--- a/Tests/TdbmGraphqlTestingKernel.php
+++ b/Tests/TdbmGraphqlTestingKernel.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 use TheCodingMachine\Graphqlite\Bundle\GraphqliteBundle;
 use TheCodingMachine\TDBM\Bundle\TdbmBundle;
-use TheCodingMachine\Tdbm\Graphql\Bundle\TdbmGraphqlBundle;
+use TheCodingMachine\Tdbm\Graphql\Bundle\TheCodingMachineTdbmGraphqlBundle;
 
 class TdbmGraphqlTestingKernel extends Kernel
 {
@@ -32,7 +32,7 @@ class TdbmGraphqlTestingKernel extends Kernel
             new DoctrineBundle(),
             new TdbmBundle(),
             new GraphqliteBundle(),
-            new TdbmGraphqlBundle(),
+            new TheCodingMachineTdbmGraphqlBundle(),
         ];
     }
 

--- a/TheCodingMachineTdbmGraphqlBundle.php
+++ b/TheCodingMachineTdbmGraphqlBundle.php
@@ -6,7 +6,7 @@ namespace TheCodingMachine\Tdbm\Graphql\Bundle;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use TheCodingMachine\Tdbm\Graphql\Bundle\DependencyInjection\TdbmGraphqlCompilerPass;
+use TheCodingMachine\Tdbm\Graphql\Bundle\DependencyInjection\TheCodingMachineTdbmGraphqlCompilerPass;
 
 class TheCodingMachineTdbmGraphqlBundle extends Bundle
 {
@@ -14,6 +14,6 @@ class TheCodingMachineTdbmGraphqlBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new TdbmGraphqlCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new TheCodingMachineTdbmGraphqlCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 }

--- a/TheCodingMachineTdbmGraphqlBundle.php
+++ b/TheCodingMachineTdbmGraphqlBundle.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use TheCodingMachine\Tdbm\Graphql\Bundle\DependencyInjection\TdbmGraphqlCompilerPass;
 
-class TdbmGraphqlBundle extends Bundle
+class TheCodingMachineTdbmGraphqlBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "php-coveralls/php-coveralls": "^2.1"
   },
   "scripts": {
-    "phpstan": "phpstan analyse TdbmGraphqlBundle.php DependencyInjection/ Resources/ -c phpstan.neon --level=7 --no-progress"
+    "phpstan": "phpstan analyse TheCodingMachineTdbmGraphqlBundle.php DependencyInjection/ Resources/ -c phpstan.neon --level=7 --no-progress"
   },
   "autoload" : {
     "psr-4" : {


### PR DESCRIPTION
The vendor part was missing in the name.