### PR TITLE
Add 'graphql.field_middleware' tag to NoBeanFoundExceptionWrapperMiddleware

### DIFF
--- a/Resources/config/container/tdbmgraphql.xml
+++ b/Resources/config/container/tdbmgraphql.xml
@@ -10,6 +10,9 @@
         <defaults autowire="true" autoconfigure="true" public="false" />
         
         <service id="TheCodingMachine\Tdbm\GraphQL\GraphQLTypeAnnotator" />
+        <service id="TheCodingMachine\Tdbm\GraphQL\Middlewares\NoBeanFoundExceptionWrapperMiddleware">
+            <tag name="graphql.field_middleware"/>
+        </service>
     </services>
 
 </container>


### PR DESCRIPTION
This add the `graphql.field_middleware` tag to the NoBeanFoundExceptionWrapperMiddleware of the [tdbm-graphql](https://github.com/thecodingmachine/tdbm-graphql) package